### PR TITLE
Request to Change Access Modifier of TokenSource for TokenCache Customization

### DIFF
--- a/src/main/java/com/scalepoint/oauth_token_client/TokenSource.java
+++ b/src/main/java/com/scalepoint/oauth_token_client/TokenSource.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 /**
  * Represents function returning token
  */
-interface TokenSource {
+public interface TokenSource {
     /**
      * @return Token
      * @throws IOException


### PR DESCRIPTION
Hello,

While attempting to customize our TokenCache, I encountered an issue with accessing TokenSource. Currently, TokenSource is defined with a package-private access modifier, which restricts its accessibility outside its package. This limitation poses a challenge in customizing TokenCache effectively.

Would it be possible to consider changing the access modifier of TokenSource to public? Making it publicly accessible would greatly enhance flexibility and facilitate custom implementations of TokenCache.

Thank you for considering this request. I believe this change could benefit other users facing similar customization needs.