### PR TITLE
Reanimate project and prepare for 2.0.0

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -1,0 +1,130 @@
+name: Build and Publish
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: maven
+          server-id: ${{ github.event_name == 'release' && 'central' || 'github' }}
+          server-username: ${{ github.event_name == 'release' && 'CENTRAL_USERNAME' || 'GITHUB_ACTOR' }}
+          server-password: ${{ github.event_name == 'release' && 'CENTRAL_TOKEN' || 'GITHUB_TOKEN' }}
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+
+      - name: Read version from pom.xml
+        id: get-version
+        run: |
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "pom_version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Validate pom.xml version has -SNAPSHOT suffix
+        run: |
+          POM_VERSION=${{ steps.get-version.outputs.pom_version }}
+          echo "POM version: $POM_VERSION"
+          if [[ "$POM_VERSION" != *"-SNAPSHOT" ]]; then
+            echo "::error::pom.xml version must end with -SNAPSHOT, but is '$POM_VERSION'"
+            exit 1
+          fi
+
+      - name: Validate release tag matches POM version
+        if: github.event_name == 'release'
+        run: |
+          TAG_VERSION=${GITHUB_REF#refs/tags/v}
+          POM_VERSION=${{ steps.get-version.outputs.pom_version }}
+          EXPECTED_TAG="${POM_VERSION%-SNAPSHOT}"
+          echo "GitHub tag: $TAG_VERSION"
+          echo "Expected from POM: $EXPECTED_TAG"
+          if [ "$TAG_VERSION" != "$EXPECTED_TAG" ]; then
+            echo "::error::Tag v$TAG_VERSION does not match pom.xml version $POM_VERSION without -SNAPSHOT suffix"
+            exit 1
+          fi
+
+      - name: Build and test
+        run: mvn --batch-mode verify
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Publish Test Results
+        uses: dorny/test-reporter@dc3a92680fcc15842eef52e8c4606ea7ce6bd3f3 # v2.1.1
+        if: success() || failure()
+        with:
+          name: Test Results
+          path: target/surefire-reports/*.xml
+          reporter: java-junit
+          fail-on-error: false
+
+      - name: Publish to GitHub Packages
+        if: github.event_name == 'push'
+        run: mvn --batch-mode deploy -DskipTests -DaltDeploymentRepository=github::https://maven.pkg.github.com/${{ github.repository }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set release version for Maven Central
+        if: github.event_name == 'release'
+        run: |
+          POM_VERSION=${{ steps.get-version.outputs.pom_version }}
+          RELEASE_VERSION="${POM_VERSION%-SNAPSHOT}"
+          mvn versions:set -DnewVersion="$RELEASE_VERSION" -DgenerateBackupPoms=false
+
+      - name: Update release with Maven Central links
+        if: github.event_name == 'release'
+        run: |
+          RELEASE_VERSION="${{ steps.get-version.outputs.pom_version }}"
+          RELEASE_VERSION="${RELEASE_VERSION%-SNAPSHOT}"
+          
+          # Get existing release body first
+          EXISTING_BODY=$(gh release view ${{ github.event.release.tag_name }} --json body -q .body)
+          
+          # Start with existing body if it exists
+          if [ -n "$EXISTING_BODY" ] && [ "$EXISTING_BODY" != "null" ]; then
+            echo "$EXISTING_BODY" > release_body.md
+            echo "" >> release_body.md
+            echo "---" >> release_body.md
+            echo "" >> release_body.md
+          fi
+          
+          # Append Maven Central links
+          cat << EOF >> release_body.md
+          ## 📦 Maven Central
+
+          This release is available at https://central.sonatype.com/artifact/com.scalepoint/oauth-token-client/${RELEASE_VERSION}
+
+          \`\`\`xml
+          <dependency>
+              <groupId>com.scalepoint</groupId>
+              <artifactId>oauth-token-client</artifactId>
+              <version>${RELEASE_VERSION}</version>
+          </dependency>
+          \`\`\`
+          EOF
+          
+          # Update the release
+          gh release edit ${{ github.event.release.tag_name }} --notes-file release_body.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to Maven Central
+        if: github.event_name == 'release'
+        run: mvn --batch-mode deploy -DskipTests
+        env:
+          CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Install with Maven:
 <dependency>
     <groupId>com.scalepoint</groupId>
     <artifactId>oauth-token-client</artifactId>
-    <version>1.1.1</version>
+    <version>2.0.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <developers>
         <developer>
             <name>Yuriy Ostapenko</name>
-            <email>uncleyo@users.noreply.github.com</email>
+            <email>yuriyostapenko@users.noreply.github.com</email>
             <organization>Scalepoint A/S</organization>
             <organizationUrl>https://scalepoint.com</organizationUrl>
         </developer>
@@ -35,91 +35,16 @@
     </scm>
 
     <properties>
-        <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>17</maven.compiler.release>
+        <central-publishing-maven-plugin.version>0.8.0</central-publishing-maven-plugin.version>
+        <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
+        <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
+        <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
+        <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
     </properties>
 
-    <profiles>
-        <profile>
-            <id>ci</id>
-            <activation>
-                <property>
-                    <name>env.CI</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.sonatype.central</groupId>
-                        <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.8.0</version>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <publishingServerId>central</publishingServerId>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <configuration>
-                            <failOnWarning>true</failOnWarning>
-                            <showWarnings>true</showWarnings>
-                            <compilerArgs>
-                                <arg>-Xlint:all</arg>
-                                <arg>-Werror</arg>
-                            </compilerArgs>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                                <goals>
-                                    <goal>jar-no-fork</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                                <configuration>
-                                    <gpgArguments>
-                                        <arg>--pinentry-mode</arg>
-                                        <arg>loopback</arg>
-                                    </gpgArguments>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
-
     <dependencies>
-
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt</artifactId>
@@ -143,6 +68,100 @@
             <version>5.15.0</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>ci</id>
+            <activation>
+                <property>
+                    <name>env.CI</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>${central-publishing-maven-plugin.version}</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>${maven-compiler-plugin.version}</version>
+                        <configuration>
+                            <failOnWarning>true</failOnWarning>
+                            <showWarnings>true</showWarnings>
+                            <compilerArgs>
+                                <arg>-Xlint:all</arg>
+                                <arg>-Werror</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>${maven-source-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>${maven-javadoc-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>${maven-gpg-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+    <distributionManagement>
+        <repository>
+            <id>central</id>
+            <url>https://central.sonatype.com/api/v1/publish</url>
+        </repository>
+        <snapshotRepository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/scalepoint-tech/oauth-token-java-client</url>
+        </snapshotRepository>
+    </distributionManagement>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -64,11 +64,6 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.19.2</version>
         </dependency>
-        <dependency>
-            <groupId>net.jodah</groupId>
-            <artifactId>expiringmap</artifactId>
-            <version>0.5.11</version>
-        </dependency>
 
         <dependency>
             <groupId>org.testng</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,33 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>ci</id>
+            <activation>
+                <property>
+                    <name>env.CI</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <failOnWarning>true</failOnWarning>
+                            <showWarnings>true</showWarnings>
+                            <compilerArgs>
+                                <arg>-Xlint:all</arg>
+                                <arg>-Werror</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <dependencies>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,20 +4,20 @@
 
     <groupId>com.scalepoint</groupId>
     <artifactId>oauth-token-client</artifactId>
-    <version>1.2-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>OAuth2 Token Endpoint Client</name>
     <description>Client helper for OAuth 2.0 Token endpoint. Supports "Client Credentials" flow with "client_secret", RS256 JWT "client_assertion" and custom grants.</description>
-    <url>https://github.com/Scalepoint/oauth-token-java-client</url>
+    <url>https://github.com/scalepoint-tech/oauth-token-java-client</url>
     <organization>
-        <name>Scalepoint Technologies Ltd.</name>
+        <name>Scalepoint A/S</name>
     </organization>
     <developers>
         <developer>
             <name>Yuriy Ostapenko</name>
             <email>uncleyo@users.noreply.github.com</email>
-            <organization>Scalepoint Technologies Ltd.</organization>
+            <organization>Scalepoint A/S</organization>
             <organizationUrl>https://scalepoint.com</organizationUrl>
         </developer>
     </developers>
@@ -28,9 +28,9 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:git@github.com:Scalepoint/oauth-token-java-client.git</connection>
-        <developerConnection>scm:git:git@github.com:Scalepoint/oauth-token-java-client.git</developerConnection>
-        <url>https://github.com/Scalepoint/oauth-token-java-client.git</url>
+        <connection>scm:git:git@github.com:scalepoint-tech/oauth-token-java-client.git</connection>
+        <developerConnection>scm:git:git@github.com:scalepoint-tech/oauth-token-java-client.git</developerConnection>
+        <url>https://github.com/scalepoint-tech/oauth-token-java-client.git</url>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.scalepoint</groupId>
     <artifactId>oauth-token-client</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>OAuth2 Token Endpoint Client</name>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.scalepoint</groupId>
@@ -38,20 +39,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
-    <build>
-        <plugins>
-            <plugin>
-            <groupId>org.sonatype.central</groupId>
-            <artifactId>central-publishing-maven-plugin</artifactId>
-            <version>0.8.0</version>
-            <extensions>true</extensions>
-            <configuration>
-                <publishingServerId>central</publishingServerId>
-            </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <profiles>
         <profile>
             <id>ci</id>
@@ -63,6 +50,15 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.8.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                        </configuration>
+                    </plugin>
+                    <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
                         <configuration>
@@ -73,6 +69,49 @@
                                 <arg>-Werror</arg>
                             </compilerArgs>
                         </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -34,103 +34,20 @@
     </scm>
 
     <properties>
+        <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                        </manifest>
-                    </archive>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.0</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.3</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>1.15</version>
-                <configuration>
-                    <signature>
-                        <groupId>org.codehaus.mojo.signature</groupId>
-                        <artifactId>java16</artifactId>
-                        <version>1.1</version>
-                    </signature>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>ensure-java-1.6-class-library</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.6</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>false</autoReleaseAfterClose>
-                </configuration>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.8.0</version>
+            <extensions>true</extensions>
+            <configuration>
+                <publishingServerId>central</publishingServerId>
+            </configuration>
             </plugin>
         </plugins>
     </build>
@@ -140,35 +57,29 @@
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt</artifactId>
-            <version>0.6.0</version>
+            <version>0.12.6</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.7.1</version>
+            <version>2.19.2</version>
         </dependency>
         <dependency>
             <groupId>net.jodah</groupId>
             <artifactId>expiringmap</artifactId>
-            <version>0.5.6</version>
+            <version>0.5.11</version>
         </dependency>
 
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>6.9.10</version>
+            <version>7.11.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-netty</artifactId>
-            <version>3.10.4</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.13</version>
+            <version>5.15.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/com/scalepoint/oauth_token_client/CertificateUtil.java
+++ b/src/main/java/com/scalepoint/oauth_token_client/CertificateUtil.java
@@ -1,7 +1,5 @@
 package com.scalepoint.oauth_token_client;
 
-import io.jsonwebtoken.impl.Base64UrlCodec;
-
 import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -30,7 +28,7 @@ final class CertificateUtil {
 
         md.update(der);
         byte[] digest = md.digest();
-        return new Base64UrlCodec().encode(digest);
+        return java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
     }
 
     static Boolean checkIfMatch(PrivateKey privateKey, X509Certificate certificate) {

--- a/src/main/java/com/scalepoint/oauth_token_client/ClientCredentialsGrantTokenClient.java
+++ b/src/main/java/com/scalepoint/oauth_token_client/ClientCredentialsGrantTokenClient.java
@@ -40,7 +40,7 @@ public class ClientCredentialsGrantTokenClient extends CustomGrantTokenClient {
      * @throws IOException Exception during token endpoint communication
      */
     @SuppressWarnings("UnusedReturnValue")
-    public String getToken(final String... scopes) throws IOException {
+    public String getToken(final String... scopes) throws IOException, InterruptedException {
         return getTokenInternal(Collections.<NameValuePair>emptyList(), scopes);
     }
 

--- a/src/main/java/com/scalepoint/oauth_token_client/CustomGrantTokenClient.java
+++ b/src/main/java/com/scalepoint/oauth_token_client/CustomGrantTokenClient.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-@SuppressWarnings("WeakerAccess")
 public abstract class CustomGrantTokenClient {
     private final ClientCredentials clientCredentials;
     private final TokenEndpointHttpClient tokenEndpointHttpClient;
@@ -26,7 +25,7 @@ public abstract class CustomGrantTokenClient {
      * @return Access token
      * @throws IOException Exception during token endpoint communication
      */
-    protected String getTokenInternal(final List<NameValuePair> parameters, final String... scopes) throws IOException {
+    protected String getTokenInternal(final List<NameValuePair> parameters, final String... scopes) throws IOException, InterruptedException {
 
         final String scopeString =
                 (scopes == null || scopes.length < 1)
@@ -37,7 +36,7 @@ public abstract class CustomGrantTokenClient {
 
         return cache.get(cacheKey, new TokenSource() {
             @Override
-            public ExpiringToken get() throws IOException {
+            public ExpiringToken get() throws IOException, InterruptedException {
 
                 List<NameValuePair> form = new ArrayList<NameValuePair>();
 

--- a/src/main/java/com/scalepoint/oauth_token_client/DigestUtil.java
+++ b/src/main/java/com/scalepoint/oauth_token_client/DigestUtil.java
@@ -1,24 +1,18 @@
 package com.scalepoint.oauth_token_client;
 
-import javax.xml.bind.DatatypeConverter;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
 
 class DigestUtil {
     static String sha1Hex(String data) {
-        MessageDigest digest = null;
         try {
-            digest = MessageDigest.getInstance("SHA-1");
+            MessageDigest digest = MessageDigest.getInstance("SHA-1");
+            byte[] digestBytes = digest.digest(data.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digestBytes);
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
-        try {
-            digest.update(data.getBytes("utf8"));
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
-        byte[] digestBytes = digest.digest();
-        return DatatypeConverter.printHexBinary(digestBytes);
     }
 }

--- a/src/main/java/com/scalepoint/oauth_token_client/InMemoryTokenCache.java
+++ b/src/main/java/com/scalepoint/oauth_token_client/InMemoryTokenCache.java
@@ -50,13 +50,12 @@ public class InMemoryTokenCache implements TokenCache {
         // Token is missing or expired - fetch a new one
         ExpiringToken token = underlyingSource.get();
         if (token.getExpiresInSeconds() <= 0) {
-            throw new IllegalArgumentException("Authorization server does not provide token expiration information. Consider using NoCache or custom cache implementation to avoid performance penalty caused by locking.");
+            throw new IllegalArgumentException("Authorization server does not provide token expiration information. Consider using NoCache or custom cache implementation.");
         }
-        
-        // Use compute for thread-safe update, but we already have the token
+
+        // Use compute for thread-safe update, even though we already have the token
         CachedToken newToken = new CachedToken(token.getToken(), token.getExpiresInSeconds());
         cache.compute(cacheKey, (key, existingToken) -> {
-            // Double-check: another thread might have updated it with a fresh token
             if (existingToken != null && !existingToken.isExpired()) {
                 return existingToken;
             }

--- a/src/main/java/com/scalepoint/oauth_token_client/InMemoryTokenCache.java
+++ b/src/main/java/com/scalepoint/oauth_token_client/InMemoryTokenCache.java
@@ -39,7 +39,7 @@ public class InMemoryTokenCache implements TokenCache {
      * @throws IOException Exception from underlying source
      */
     @Override
-    public String get(String cacheKey, TokenSource underlyingSource) throws IOException {
+    public String get(String cacheKey, TokenSource underlyingSource) throws IOException, InterruptedException {
         CachedToken cachedToken = cache.get(cacheKey);
         
         // Check if we have a valid (non-expired) token

--- a/src/main/java/com/scalepoint/oauth_token_client/JwtBearerClientAssertionCredentials.java
+++ b/src/main/java/com/scalepoint/oauth_token_client/JwtBearerClientAssertionCredentials.java
@@ -32,7 +32,7 @@ public class JwtBearerClientAssertionCredentials implements ClientCredentials {
 
     @Override
     public List<NameValuePair> getPostParams() {
-        String assertionToken = assertionFactory.CreateAssertionToken();
+        String assertionToken = assertionFactory.createAssertionToken();
         ArrayList<NameValuePair> params = new ArrayList<NameValuePair>();
         params.add(new NameValuePair("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"));
         params.add(new NameValuePair("client_assertion", assertionToken));

--- a/src/main/java/com/scalepoint/oauth_token_client/NoCache.java
+++ b/src/main/java/com/scalepoint/oauth_token_client/NoCache.java
@@ -14,7 +14,7 @@ public class NoCache implements TokenCache {
      * @throws IOException Exception from underlying source
      */
     @Override
-    public String get(String cacheKey, TokenSource underlyingSource) throws IOException {
+    public String get(String cacheKey, TokenSource underlyingSource) throws IOException, InterruptedException {
         return underlyingSource.get().getToken();
     }
 }

--- a/src/main/java/com/scalepoint/oauth_token_client/ResourceScopedAccessGrantTokenClient.java
+++ b/src/main/java/com/scalepoint/oauth_token_client/ResourceScopedAccessGrantTokenClient.java
@@ -23,7 +23,7 @@ public class ResourceScopedAccessGrantTokenClient extends CustomGrantTokenClient
      * @throws IOException Exception during token endpoint communication
      */
     @SuppressWarnings("UnusedReturnValue")
-    public String getToken(ResourceScopedAccessGrantParameters parameters) throws IOException {
+    public String getToken(ResourceScopedAccessGrantParameters parameters) throws IOException, InterruptedException {
         return getTokenInternal(getPostParams(parameters), parameters.getScope());
     }
 

--- a/src/main/java/com/scalepoint/oauth_token_client/TokenCache.java
+++ b/src/main/java/com/scalepoint/oauth_token_client/TokenCache.java
@@ -12,5 +12,5 @@ public interface TokenCache {
      * @return Token from either cache or underlying source
      * @throws IOException Exception from underlying cache
      */
-    String get(String cacheKey, TokenSource underlyingSource) throws IOException;
+    String get(String cacheKey, TokenSource underlyingSource) throws IOException, InterruptedException;
 }

--- a/src/main/java/com/scalepoint/oauth_token_client/TokenSource.java
+++ b/src/main/java/com/scalepoint/oauth_token_client/TokenSource.java
@@ -10,5 +10,5 @@ public interface TokenSource {
      * @return Token
      * @throws IOException
      */
-    ExpiringToken get() throws IOException;
+    ExpiringToken get() throws IOException, InterruptedException;
 }

--- a/src/test/java/com/scalepoint/oauth_token_client/BadRequestCallback.java
+++ b/src/test/java/com/scalepoint/oauth_token_client/BadRequestCallback.java
@@ -1,12 +1,12 @@
 package com.scalepoint.oauth_token_client;
 
-import org.mockserver.mock.action.ExpectationCallback;
+import org.mockserver.mock.action.ExpectationResponseCallback;
 import org.mockserver.model.Header;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 
 @SuppressWarnings("WeakerAccess")
-public class BadRequestCallback implements ExpectationCallback {
+public class BadRequestCallback implements ExpectationResponseCallback {
     @Override
     public HttpResponse handle(HttpRequest httpRequest) {
         return new HttpResponse()

--- a/src/test/java/com/scalepoint/oauth_token_client/ClientAssertionJwtFactoryTest.java
+++ b/src/test/java/com/scalepoint/oauth_token_client/ClientAssertionJwtFactoryTest.java
@@ -22,7 +22,7 @@ public class ClientAssertionJwtFactoryTest {
         CertificateWithPrivateKey keyPair = TestCertificateHelper.load();
         thumbprint = CertificateUtil.getThumbprint(keyPair.getCertificate());
         ClientAssertionJwtFactory factory = new ClientAssertionJwtFactory(TOKEN_ENDPOINT_URI, CLIENT_ID, keyPair);
-        String tokenString = factory.CreateAssertionToken();
+        String tokenString = factory.createAssertionToken();
         // Use the PUBLIC key from the certificate to verify the JWT signature, not the private key
         token = Jwts.parser().verifyWith(keyPair.getCertificate().getPublicKey()).build().parseSignedClaims(tokenString);
     }

--- a/src/test/java/com/scalepoint/oauth_token_client/ClientAssertionTokenClientTest.java
+++ b/src/test/java/com/scalepoint/oauth_token_client/ClientAssertionTokenClientTest.java
@@ -1,6 +1,6 @@
 package com.scalepoint.oauth_token_client;
 
-import org.mockserver.model.HttpCallback;
+import org.mockserver.model.HttpClassCallback;
 import org.mockserver.model.HttpRequest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -10,7 +10,6 @@ import java.io.IOException;
 import static org.mockserver.matchers.Times.exactly;
 import static org.mockserver.model.HttpRequest.request;
 
-@SuppressWarnings("unused")
 public class ClientAssertionTokenClientTest extends MockServerTestBase {
 
     @Test
@@ -23,7 +22,7 @@ public class ClientAssertionTokenClientTest extends MockServerTestBase {
                         .withPath("/oauth2/token"),
                 exactly(1)
         )
-                .callback(HttpCallback.callback().withCallbackClass(SuccessfulExpectationCallback.class.getName()));
+                .respond(HttpClassCallback.callback(SuccessfulExpectationCallback.class));
 
         ClientCredentialsGrantTokenClient tokenClient = new ClientCredentialsGrantTokenClient(
                 tokenEndpointUri,
@@ -47,7 +46,7 @@ public class ClientAssertionTokenClientTest extends MockServerTestBase {
                 request,
                 exactly(1)
         )
-                .callback(HttpCallback.callback().withCallbackClass(SuccessfulExpectationCallback.class.getName()));
+                .respond(HttpClassCallback.callback(SuccessfulExpectationCallback.class));
 
         ClientCredentialsGrantTokenClient tokenClient = new ClientCredentialsGrantTokenClient(
                 tokenEndpointUri,
@@ -72,7 +71,7 @@ public class ClientAssertionTokenClientTest extends MockServerTestBase {
                         .withPath("/oauth2/token"),
                 exactly(1)
         )
-                .callback(HttpCallback.callback().withCallbackClass(ValidClientAssertionExpectationCallback.class.getName()));
+                .respond(HttpClassCallback.callback(ValidClientAssertionExpectationCallback.class));
 
         ClientCredentialsGrantTokenClient tokenClient = new ClientCredentialsGrantTokenClient(
                 tokenEndpointUri,
@@ -95,7 +94,7 @@ public class ClientAssertionTokenClientTest extends MockServerTestBase {
                         .withPath("/oauth2/token"),
                 exactly(1)
         )
-                .callback(HttpCallback.callback().withCallbackClass(BadRequestCallback.class.getName()));
+                .respond(HttpClassCallback.callback(BadRequestCallback.class));
 
         ClientCredentialsGrantTokenClient tokenClient = new ClientCredentialsGrantTokenClient(
                 tokenEndpointUri,
@@ -118,7 +117,7 @@ public class ClientAssertionTokenClientTest extends MockServerTestBase {
                         .withPath("/oauth2/token"),
                 exactly(1)
         )
-                .callback(HttpCallback.callback().withCallbackClass(SuccessfulExpectationCallback.class.getName()));
+                .respond(HttpClassCallback.callback(SuccessfulExpectationCallback.class));
 
         ClientCredentialsGrantTokenClient tokenClient = new ClientCredentialsGrantTokenClient(
                 tokenEndpointUri,

--- a/src/test/java/com/scalepoint/oauth_token_client/ClientSecretTokenClientTest.java
+++ b/src/test/java/com/scalepoint/oauth_token_client/ClientSecretTokenClientTest.java
@@ -1,6 +1,6 @@
 package com.scalepoint.oauth_token_client;
 
-import org.mockserver.model.HttpCallback;
+import org.mockserver.model.HttpClassCallback;
 import org.mockserver.model.HttpRequest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -10,7 +10,6 @@ import java.io.IOException;
 import static org.mockserver.matchers.Times.exactly;
 import static org.mockserver.model.HttpRequest.request;
 
-@SuppressWarnings("unused")
 public class ClientSecretTokenClientTest extends MockServerTestBase {
 
     @Test
@@ -23,7 +22,7 @@ public class ClientSecretTokenClientTest extends MockServerTestBase {
                         .withPath("/oauth2/token"),
                 exactly(1)
         )
-                .callback(HttpCallback.callback().withCallbackClass(SuccessfulExpectationCallback.class.getName()));
+                .respond(HttpClassCallback.callback().withCallbackClass(SuccessfulExpectationCallback.class.getName()));
 
         ClientCredentialsGrantTokenClient tokenClient = new ClientCredentialsGrantTokenClient(tokenEndpointUri, new ClientSecretCredentials("clientid", "password"));
         tokenClient.getToken("success");
@@ -40,7 +39,7 @@ public class ClientSecretTokenClientTest extends MockServerTestBase {
                 request,
                 exactly(1)
         )
-                .callback(HttpCallback.callback().withCallbackClass(SuccessfulExpectationCallback.class.getName()));
+                .respond(HttpClassCallback.callback().withCallbackClass(SuccessfulExpectationCallback.class.getName()));
 
         ClientCredentialsGrantTokenClient tokenClient = new ClientCredentialsGrantTokenClient(tokenEndpointUri, new ClientSecretCredentials("clientid", "password"));
         tokenClient.getToken("cache");
@@ -58,7 +57,7 @@ public class ClientSecretTokenClientTest extends MockServerTestBase {
                         .withPath("/oauth2/token"),
                 exactly(1)
         )
-                .callback(HttpCallback.callback().withCallbackClass(ValidClientSecretExpectationCallback.class.getName()));
+                .respond(HttpClassCallback.callback().withCallbackClass(ValidClientSecretExpectationCallback.class.getName()));
 
         ClientCredentialsGrantTokenClient tokenClient = new ClientCredentialsGrantTokenClient(tokenEndpointUri, new ClientSecretCredentials("clientid", "password"));
         tokenClient.getToken("scope1", "scope2");
@@ -74,7 +73,7 @@ public class ClientSecretTokenClientTest extends MockServerTestBase {
                         .withPath("/oauth2/token"),
                 exactly(1)
         )
-                .callback(HttpCallback.callback().withCallbackClass(BadRequestCallback.class.getName()));
+                .respond(HttpClassCallback.callback().withCallbackClass(BadRequestCallback.class.getName()));
 
         ClientCredentialsGrantTokenClient tokenClient = new ClientCredentialsGrantTokenClient(tokenEndpointUri, new ClientSecretCredentials("clientid", "password"));
         tokenClient.getToken("badRequest");
@@ -90,7 +89,7 @@ public class ClientSecretTokenClientTest extends MockServerTestBase {
                         .withPath("/oauth2/token"),
                 exactly(1)
         )
-                .callback(HttpCallback.callback().withCallbackClass(SuccessfulExpectationCallback.class.getName()));
+                .respond(HttpClassCallback.callback().withCallbackClass(SuccessfulExpectationCallback.class.getName()));
 
         ClientCredentialsGrantTokenClient tokenClient = new ClientCredentialsGrantTokenClient(tokenEndpointUri, new ClientSecretCredentials("clientid", "password"));
         tokenClient.getToken();

--- a/src/test/java/com/scalepoint/oauth_token_client/ResourceScopedAccessGrantClientTest.java
+++ b/src/test/java/com/scalepoint/oauth_token_client/ResourceScopedAccessGrantClientTest.java
@@ -1,6 +1,6 @@
 package com.scalepoint.oauth_token_client;
 
-import org.mockserver.model.HttpCallback;
+import org.mockserver.model.HttpClassCallback;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -8,7 +8,6 @@ import java.io.IOException;
 import static org.mockserver.matchers.Times.exactly;
 import static org.mockserver.model.HttpRequest.request;
 
-@SuppressWarnings("unused")
 public class ResourceScopedAccessGrantClientTest extends MockServerTestBase {
 
     @Test
@@ -21,7 +20,7 @@ public class ResourceScopedAccessGrantClientTest extends MockServerTestBase {
                         .withPath("/oauth2/token"),
                 exactly(1)
         )
-                .callback(HttpCallback.callback().withCallbackClass(SuccessfulExpectationCallback.class.getName()));
+                .respond(HttpClassCallback.callback().withCallbackClass(SuccessfulExpectationCallback.class.getName()));
 
         ResourceScopedAccessGrantTokenClient tokenClient = new ResourceScopedAccessGrantTokenClient(
                 tokenEndpointUri,
@@ -44,7 +43,7 @@ public class ResourceScopedAccessGrantClientTest extends MockServerTestBase {
                         .withPath("/oauth2/token"),
                 exactly(1)
         )
-                .callback(HttpCallback.callback().withCallbackClass(ValidResourceScopedAccessRequestCallback.class.getName()));
+                .respond(HttpClassCallback.callback().withCallbackClass(ValidResourceScopedAccessRequestCallback.class.getName()));
 
         ResourceScopedAccessGrantTokenClient tokenClient = new ResourceScopedAccessGrantTokenClient(
                 tokenEndpointUri,
@@ -67,7 +66,7 @@ public class ResourceScopedAccessGrantClientTest extends MockServerTestBase {
                         .withPath("/oauth2/token"),
                 exactly(1)
         )
-                .callback(HttpCallback.callback().withCallbackClass(BadRequestCallback.class.getName()));
+                .respond(HttpClassCallback.callback().withCallbackClass(BadRequestCallback.class.getName()));
 
         ResourceScopedAccessGrantTokenClient tokenClient = new ResourceScopedAccessGrantTokenClient(
                 tokenEndpointUri,
@@ -90,7 +89,7 @@ public class ResourceScopedAccessGrantClientTest extends MockServerTestBase {
                         .withPath("/oauth2/token"),
                 exactly(1)
         )
-                .callback(HttpCallback.callback().withCallbackClass(SuccessfulExpectationCallback.class.getName()));
+                .respond(HttpClassCallback.callback().withCallbackClass(SuccessfulExpectationCallback.class.getName()));
 
         ResourceScopedAccessGrantTokenClient tokenClient = new ResourceScopedAccessGrantTokenClient(
                 tokenEndpointUri,

--- a/src/test/java/com/scalepoint/oauth_token_client/SuccessfulExpectationCallback.java
+++ b/src/test/java/com/scalepoint/oauth_token_client/SuccessfulExpectationCallback.java
@@ -1,12 +1,11 @@
 package com.scalepoint.oauth_token_client;
 
-import org.mockserver.mock.action.ExpectationCallback;
+import org.mockserver.mock.action.ExpectationResponseCallback;
 import org.mockserver.model.Header;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 
-@SuppressWarnings("WeakerAccess")
-public class SuccessfulExpectationCallback implements ExpectationCallback {
+public class SuccessfulExpectationCallback implements ExpectationResponseCallback {
     @Override
     public HttpResponse handle(HttpRequest httpRequest) {
         return new HttpResponse()

--- a/src/test/java/com/scalepoint/oauth_token_client/ValidClientAssertionExpectationCallback.java
+++ b/src/test/java/com/scalepoint/oauth_token_client/ValidClientAssertionExpectationCallback.java
@@ -14,7 +14,7 @@ public class ValidClientAssertionExpectationCallback extends ValidRequestExpecta
             return false;
 
         CertificateWithPrivateKey keyPair = TestCertificateHelper.load();
-        Jwts.parser().setSigningKey(keyPair.getPrivateKey()).parseClaimsJws(params.get("client_assertion"));
+        Jwts.parser().verifyWith(keyPair.getCertificate().getPublicKey()).build().parseSignedClaims(params.get("client_assertion"));
 
         return true;
     }

--- a/src/test/java/com/scalepoint/oauth_token_client/ValidRequestExpectationCallback.java
+++ b/src/test/java/com/scalepoint/oauth_token_client/ValidRequestExpectationCallback.java
@@ -1,17 +1,16 @@
 package com.scalepoint.oauth_token_client;
 
-import org.apache.commons.lang3.CharEncoding;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
-import org.mockserver.mock.action.ExpectationCallback;
+import org.mockserver.mock.action.ExpectationResponseCallback;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 
-abstract class ValidRequestExpectationCallback implements ExpectationCallback {
+abstract class ValidRequestExpectationCallback implements ExpectationResponseCallback {
     @Override
     public HttpResponse handle(HttpRequest httpRequest) {
 
@@ -24,7 +23,7 @@ abstract class ValidRequestExpectationCallback implements ExpectationCallback {
 
     private boolean isValid(HttpRequest httpRequest) {
         String body = (String) httpRequest.getBody().getValue();
-        List<NameValuePair> parsedParams = URLEncodedUtils.parse(body, Charset.forName(CharEncoding.UTF_8));
+        List<NameValuePair> parsedParams = URLEncodedUtils.parse(body, StandardCharsets.UTF_8);
         HashMap<String, String> params = new HashMap<String, String>();
         for (NameValuePair p : parsedParams) params.put(p.getName(), p.getValue());
         return isValid(params);

--- a/src/test/java/com/scalepoint/oauth_token_client/ValidResourceScopedAccessRequestCallback.java
+++ b/src/test/java/com/scalepoint/oauth_token_client/ValidResourceScopedAccessRequestCallback.java
@@ -5,7 +5,6 @@ import io.jsonwebtoken.Jwts;
 import java.util.HashMap;
 
 public class ValidResourceScopedAccessRequestCallback extends ValidRequestExpectationCallback {
-    @SuppressWarnings("RedundantIfStatement")
     @Override
     protected boolean isValid(HashMap<String, String> params) {
         if (!params.get("grant_type").equals("urn:scalepoint:params:oauth:grant-type:resource-scoped-access")) return false;
@@ -14,7 +13,7 @@ public class ValidResourceScopedAccessRequestCallback extends ValidRequestExpect
             return false;
 
         CertificateWithPrivateKey keyPair = TestCertificateHelper.load();
-        Jwts.parser().setSigningKey(keyPair.getPrivateKey()).parseClaimsJws(params.get("client_assertion"));
+        Jwts.parser().verifyWith(keyPair.getCertificate().getPublicKey()).build().parseSignedClaims(params.get("client_assertion"));
 
         if (!params.get("resource").equals("resource")) return false;
         if (!params.get("amr").equals("pwd otp mfa")) return false;


### PR DESCRIPTION
This PR adds the following changes:
- Upgrade to JDK 17 and all latest versions of dependencies
- Fix breaking changes and deprecated usages
- Remove some dependencies in favor of JDK features, such as `expiringmap` is now replaced with `ConcurrentMap`
- Replaced HttpURLConnection with JDK 11+ HttpClient
- Move from old OSSRH to Maven Central for publishing
- Migrate CI/CD to GitHub Actions

_Co-authored with Claude and Copilot 😄_