### PR TITLE
Add workflow dispatch

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
   release:
     types: [published]
 


### PR DESCRIPTION
So it can be triggered manually if automatic trigger failed (such as now due to used action blocked by org settings)