### PR TITLE
Rename `resource` parameter to `target` for resource scoped grant.

### DIFF
--- a/src/main/java/com/scalepoint/oauth_token_client/ResourceScopedAccessGrantParameters.java
+++ b/src/main/java/com/scalepoint/oauth_token_client/ResourceScopedAccessGrantParameters.java
@@ -6,30 +6,30 @@ package com.scalepoint.oauth_token_client;
 @SuppressWarnings("WeakerAccess")
 public class ResourceScopedAccessGrantParameters {
     private final String scope;
-    private final String resource;
+    private final String target;
     private String tenantId;
     private String[] amr;
 
     /**
      * Creates new ResourceScopedAccessGrantParameters
      * @param scope OAuth2 scope
-     * @param resource Specific resource identifier
+     * @param target Specific resource identifier
      */
-    public ResourceScopedAccessGrantParameters(String scope, String resource) {
+    public ResourceScopedAccessGrantParameters(String scope, String target) {
         this.scope = scope;
-        this.resource = resource;
+        this.target = target;
     }
 
     /**
      * Creates new ResourceScopedAccessGrantParameters
      * @param scope OAuth2 scope
-     * @param resource Specific resource identifier
+     * @param target Specific resource identifier
      * @param tenantId Resource tenant identifier
      * @param amr Original authentication method references
      */
     @SuppressWarnings("SameParameterValue")
-    public ResourceScopedAccessGrantParameters(String scope, String resource, String tenantId, String[] amr) {
-        this(scope, resource);
+    public ResourceScopedAccessGrantParameters(String scope, String target, String tenantId, String[] amr) {
+        this(scope, target);
         this.tenantId = tenantId;
         this.amr = amr;
     }
@@ -48,8 +48,8 @@ public class ResourceScopedAccessGrantParameters {
      *
      * @return Specific resource identifier
      */
-    public String getResource() {
-        return resource;
+    public String getTarget() {
+        return target;
     }
 
     /**

--- a/src/main/java/com/scalepoint/oauth_token_client/ResourceScopedAccessGrantTokenClient.java
+++ b/src/main/java/com/scalepoint/oauth_token_client/ResourceScopedAccessGrantTokenClient.java
@@ -36,7 +36,7 @@ public class ResourceScopedAccessGrantTokenClient extends CustomGrantTokenClient
 
     private List<NameValuePair> getPostParams(ResourceScopedAccessGrantParameters parameters) {
         ArrayList<NameValuePair> params = new ArrayList<NameValuePair>();
-        params.add(new NameValuePair("resource", parameters.getResource()));
+        params.add(new NameValuePair("target", parameters.getTarget()));
         String tenantId = parameters.getTenantId();
         if (tenantId != null) {
             params.add(new NameValuePair("tenantId", tenantId));

--- a/src/test/java/com/scalepoint/oauth_token_client/ValidResourceScopedAccessRequestCallback.java
+++ b/src/test/java/com/scalepoint/oauth_token_client/ValidResourceScopedAccessRequestCallback.java
@@ -15,7 +15,7 @@ public class ValidResourceScopedAccessRequestCallback extends ValidRequestExpect
         CertificateWithPrivateKey keyPair = TestCertificateHelper.load();
         Jwts.parser().verifyWith(keyPair.getCertificate().getPublicKey()).build().parseSignedClaims(params.get("client_assertion"));
 
-        if (!params.get("resource").equals("resource")) return false;
+        if (!params.get("target").equals("resource")) return false;
         if (!params.get("amr").equals("pwd otp mfa")) return false;
         if (!params.get("tenantId").equals("tenantId")) return false;
 


### PR DESCRIPTION
While resource is still supported for backwards compatibility, it conflicts with a standard parameter in the newer OAuth specs.

This is a breaking change and will be released with v2.